### PR TITLE
Fix conda tests on Windows

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -142,6 +142,11 @@ jobs:
   - bash: conda create --yes --quiet --name gmt --channel conda-forge gmt
     displayName: Create Anaconda environment
 
+  # conda-forge doesn't provide GraphicsMagick on Windows
+  - bash: choco install graphicsmagick
+    displayName: Install GraphicsMagick on Windows
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+
   - bash: |
       source activate gmt
       bash test-gmt.sh


### PR DESCRIPTION
The conda-built GMT fails on Windows, because the bash on Azure Pipelines gives unstable PPID, which breaks GMT's modern mode.

This PR fixes it by setting GMT_SESSION_NAME