### PR TITLE
Use batch script for movie in test-gmt.bat

### DIFF
--- a/test-gmt.bat
+++ b/test-gmt.bat
@@ -30,6 +30,6 @@ REM check movie in MP4 and GIF format
 echo "gmt begin" > globe.bat
 echo "gmt coast -Rg -JG%%MOVIE_FRAME%%/20/%%MOVIE_WIDTH%% -Gmaroon -Sturquoise -Bg -X0 -Y0" >> globe.bat
 echo "gmt end" >> globe.bat
-gmt movie globe.sh -Nglobe -T12 -Fmp4 -Agif -C6ix6ix100 -Lf -Vd
+gmt movie globe.bat -Nglobe -T12 -Fmp4 -Agif -C6ix6ix100 -Lf -Vd
 
 @echo off


### PR DESCRIPTION
This PR changes test-gmt.bat to use globe.bat rather than globe.sh from test-gmt.sh.