### PR TITLE
Test 6.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ on:
 
 env:
   # The GMT version we're testing
-  GMT_VERSION: 6.1.1
+  GMT_VERSION: 6.2.0
   # disable auto-display of figures
   GMT_END_SHOW: off
   # URL of the GMT Bundle
-  GMT_BUNDLE_URL: https://github.com/GenericMappingTools/gmt/releases/download/6.1.1/gmt-6.1.1-darwin-x86_64.dmg
+  GMT_BUNDLE_URL: https://github.com/GenericMappingTools/gmt/releases/download/6.2.0/gmt-6.2.0-darwin-x86_64.dmg
 
 jobs:
   macos:
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: ["fedora:32", "fedora:33", "fedora:rawhide", "centos:7", "centos:8"]
+        image: ["fedora:33", "fedora:34", "fedora:rawhide", "centos:7", "centos:8"]
 
     steps:
       - name: Cancel Previous Runs
@@ -120,7 +120,7 @@ jobs:
         arch: ["win32", "win64"]
 
     env:
-      GMT_INSTALLER_URL: https://github.com/GenericMappingTools/gmt/releases/download/6.1.1/gmt-6.1.1-${{ matrix.arch }}.exe
+      GMT_INSTALLER_URL: https://github.com/GenericMappingTools/gmt/releases/download/6.2.0/gmt-6.2.0-${{ matrix.arch }}.exe
 
     steps:
       - name: Cancel Previous Runs

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 The GMT Team
+Copyright (c) 2019-2021 The GMT Team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and runs some basic commands to check their functionality.
 - Windows
   - Installer (x64, x86)
 - Linux
-  - Fedora (32, 33, Rawhide)
+  - Fedora (33, 34, Rawhide)
   - CentOS (7, 8)
 - Conda
   - macOS 10.15

--- a/install-gmt-centos.sh
+++ b/install-gmt-centos.sh
@@ -10,7 +10,7 @@ yum -yq copr enable genericmappingtools/gmt
 
 # See https://github.com/GenericMappingTools/gmt/issues/3433
 if [ "$(rpm -E %rhel)" == "8" ]; then
-    yum config-manager --set-enabled PowerTools
+    yum config-manager --set-enabled powertools
 fi
 
 yum -yq install gmt

--- a/install-gmt-via-bundle.sh
+++ b/install-gmt-via-bundle.sh
@@ -20,6 +20,7 @@ sudo hdiutil unmount /Volumes/${GMT_BUNDLE_NAME}
 # Add PATHs
 GMTHOME=/Applications/GMT.app/Contents/Resources
 echo "PROJ_LIB=${GMTHOME}/share/proj6" >> $GITHUB_ENV
+echo "GS_LIB=${GMTHOME}/share/ghostscript/9.53.3/Resource/Init" >> $GITHUB_ENV
 echo "MAGICK_CONFIGURE_PATH=${GMTHOME}/lib/GraphicsMagick/config" >> $GITHUB_ENV
 echo "${GMTHOME}/bin" >> $GITHUB_PATH
 

--- a/install-gmt-via-macports.sh
+++ b/install-gmt-via-macports.sh
@@ -7,10 +7,10 @@ set -x -e
 
 # Install macports
 macos_version=$(sw_vers -productVersion)
-if [[ "$macos_version" =~ "11.0" ]]; then
-	pkg="https://distfiles.macports.org/MacPorts/MacPorts-2.6.4_1-11-BigSur.pkg"
+if [[ "$macos_version" =~ "11" ]]; then
+	pkg="https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-11-BigSur.pkg"
 elif [[ "$macos_version" =~ "10.15" ]]; then
-	pkg="https://distfiles.macports.org/MacPorts/MacPorts-2.6.4-10.15-Catalina.pkg"
+	pkg="https://github.com/macports/macports-base/releases/download/v2.7.1/MacPorts-2.7.1-10.15-Catalina.pkg"
 else
 	echo "macOS version ${macos_version} not supported."
 	exit 1

--- a/install-gmt-windows.sh
+++ b/install-gmt-windows.sh
@@ -16,7 +16,7 @@ wget --quiet ${GMT_INSTALLER_URL}
 # Use 7z to extract the exe file directly and copy to C:\programs\gmt6
 7z x ${GMT_INSTALLER_FULLNAME}
 mkdir -p /c/programs/gmt6
-mv bin include lib share Uninstall.exe /c/programs/gmt6
+mv bin include lib share /c/programs/gmt6
 
 # Install graphicsmagick.
 choco install graphicsmagick

--- a/test-gmt.bat
+++ b/test-gmt.bat
@@ -30,6 +30,6 @@ REM check movie in MP4 and GIF format
 echo "gmt begin" > globe.bat
 echo "gmt coast -Rg -JG%%MOVIE_FRAME%%/20/%%MOVIE_WIDTH%% -Gmaroon -Sturquoise -Bg -X0 -Y0" >> globe.bat
 echo "gmt end" >> globe.bat
-gmt movie globe.bat -Nglobe -T12 -Fmp4 -Agif -C6ix6ix100 -Lf -Vd
+gmt movie globe.bat -Nglobe_bat -T12 -Fmp4 -Agif -C6ix6ix100 -Lf -Vd
 
 @echo off


### PR DESCRIPTION
Changes in this PR:

1. Test GMT 6.2.0
2. Fedora 32 is EOL. Now test Fedora 33, 34, and rawhide
3. Update the LICENSE year
4. The repo "PowerTools" is renamed to "powertools" since CentOS 8.3
5. Set environmental variable `GS_LIB` for macOS bundles
6. Update macports to v2.7.1