### PR TITLE
Add ffmeg to conda install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install GMT
         shell: bash -l {0}
-        run: conda install --yes gmt graphicsmagick
+        run: conda install --yes gmt graphicsmagick ffmpeg
 
       - name: Run tests
         shell: bash -l {0}


### PR DESCRIPTION
Explicitly install ffmeg for the conda jobs because it is not installed automatically since https://github.com/conda-forge/gmt-feedstock/pull/183.